### PR TITLE
Fix Course Schedule Scraping Logic

### DIFF
--- a/src/clients/vhs-website/fetch-course-details.test.ts
+++ b/src/clients/vhs-website/fetch-course-details.test.ts
@@ -39,9 +39,24 @@ const htmlWithJsonLd = `
     <dt>Dauer:</dt><dd>1 Termin</dd>
     <dt>Termine:</dt><dd>1</dd>
   </dl>
+  <!-- Sidebar lists should be ignored -->
   <ul class="termine">
     <li>Samstag • 15.11.2025 • 09:00 - 16:00 Uhr • VHS in Pasewalk • Raum 302</li>
   </ul>
+  <!-- Official schedule table -->
+  <table id="kw-kurstage">
+    <thead>
+      <tr><th>Datum</th><th>Uhrzeit</th><th>Ort</th><th>Raum</th></tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>15.11.2025</td>
+        <td>09:00 - 16:00 Uhr</td>
+        <td>VHS in Pasewalk</td>
+        <td>Raum 302</td>
+      </tr>
+    </tbody>
+  </table>
 </div>
 </body></html>
 `;
@@ -58,10 +73,31 @@ const htmlWithoutJsonLd = `
   <dt>Dauer:</dt><dd>5 Termine</dd>
   <dt>Termine:</dt><dd>5</dd>
 </dl>
+<!-- Sidebar list should be ignored -->
 <ul class="course-dates">
   <li>Montag • 10.11.2025 • 17:00 - 20:15 Uhr • VHS in Greifswald • Raum 12</li>
   <li>Mittwoch • 12.11.2025 • 17:00 - 20:15 Uhr • VHS in Greifswald • Raum 12</li>
 </ul>
+<!-- Official schedule table -->
+<table id="kw-kurstage">
+  <thead>
+    <tr><th>Datum</th><th>Uhrzeit</th><th>Ort</th><th>Raum</th></tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>10.11.2025</td>
+      <td>17:00 - 20:15 Uhr</td>
+      <td>VHS in Greifswald</td>
+      <td>Raum 12</td>
+    </tr>
+    <tr>
+      <td>12.11.2025</td>
+      <td>17:00 - 20:15 Uhr</td>
+      <td>VHS in Greifswald</td>
+      <td>Raum 12</td>
+    </tr>
+  </tbody>
+</table>
 </div>
 </body></html>
 `;


### PR DESCRIPTION
This PR addresses issue #13, correcting the extraction of course schedules by ensuring the scraping logic exclusively parses details from the schedule table identified by `#kw-kurstage`. Previously, the function incorrectly considered side content lists, which led to discrepancies in the duration and number of schedule entries. The changes involve simplifying the `extractSchedule` function to ignore sidebar lists and focus solely on the correct table, ensuring accurate data representation in the JSON output.

---

> This pull request was co-created with Cosine Genie

Original Task: [vhs-vg-courses/fjhh4249ts75](https://cosine.sh/bitgrip/vhs-vg-courses/task/fjhh4249ts75)
Author: Jan-Henrik Hempel
