### PR TITLE
Add Location Mapping for 'Torgelow, Haus an der Schleuse'

### DIFF
--- a/src/clients/vhs-website/optimize-location-address.test.ts
+++ b/src/clients/vhs-website/optimize-location-address.test.ts
@@ -71,6 +71,12 @@ describe("optimizeLocationAddress", () => {
     );
   });
 
+  it("maps Torgelow, Haus an der Schleuse", () => {
+    expect(optimizeLocationAddress("Torgelow, Haus an der Schleuse")).toBe(
+      "Haus an der Schleuse, Schleusenstraße 5b, 17358 Torgelow"
+    );
+  });
+
   it("maps Ueckermünde, Regionalschule, Gymnastikhalle", () => {
     expect(optimizeLocationAddress('Ueckermünde, Regionalschule, Gymnastikhalle')).toBe(
       'Gymnastikhalle, Regionale Schule "Ehm Welk", Goethestraße 3, 17373 Ueckermünde'


### PR DESCRIPTION
This pull request enhances the location mapping functionality by adding support for the input format 'Torgelow, Haus an der Schleuse', ensuring it maps to the standardized address 'Haus an der Schleuse, Schleusenstraße 5b, 17358 Torgelow'. 

### Changes Made:
- Updated the regex pattern in `optimize-location-address.ts` to handle both 'Torgelow, Haus an der Schleuse' and 'Haus an der Schleuse, Torgelow'. 
- Added a test case in `optimize-location-address.test.ts` to verify that the new format is correctly mapped.

### Outcomes:
- The new mapping will ensure consistency across different address formats in the VHS course location system, while still preserving the existing functionality.

---

> This pull request was co-created with Cosine Genie

Original Task: [vhs-vg-courses/gd57nxo3iaf2](https://cosine.sh/bitgrip/vhs-vg-courses/task/gd57nxo3iaf2)
Author: Jan-Henrik Hempel
