### PR TITLE
Add ICS/iCal Export Endpoint for Course API

### DIFF
--- a/src/app/api/[location]/courses/ics/route.ts
+++ b/src/app/api/[location]/courses/ics/route.ts
@@ -8,7 +8,7 @@ const FIFTEEN_MIN_SECONDS = 60 * 15;
 
 export async function GET(
   _req: NextRequest,
-  ctx: { params: { location?: string } }
+  ctx: { params: Promise<{ location?: string }> }
 ) {
   const reqId = crypto.randomUUID();
   const log = withCategory(logger, "api").child({
@@ -18,7 +18,8 @@ export async function GET(
   const end = startTimer();
 
   try {
-    const locationId = ctx.params.location?.toLowerCase();
+    const params = await ctx.params;
+    const locationId = params.location?.toLowerCase();
     if (!locationId) {
       const durationMs = end();
       log.warn({ status: 400, durationMs }, "Invalid location parameter");

--- a/src/app/api/[location]/courses/ics/route.ts
+++ b/src/app/api/[location]/courses/ics/route.ts
@@ -1,0 +1,80 @@
+import { NextRequest, NextResponse } from "next/server";
+import logger from "@/logging/logger";
+import { withCategory, startTimer, errorToObject } from "@/logging/helpers";
+import { getCourses, getLocations } from "@/clients/vhs-website/vhs-search.client";
+import { generateCourseIcs } from "@/clients/vhs-website/generate-course-ics";
+
+const FIFTEEN_MIN_SECONDS = 60 * 15;
+
+export async function GET(
+  _req: NextRequest,
+  ctx: { params: { location?: string } }
+) {
+  const reqId = crypto.randomUUID();
+  const log = withCategory(logger, "api").child({
+    requestId: reqId,
+    route: "/api/[location]/courses/ics",
+  });
+  const end = startTimer();
+
+  try {
+    const locationId = ctx.params.location?.toLowerCase();
+    if (!locationId) {
+      const durationMs = end();
+      log.warn({ status: 400, durationMs }, "Invalid location parameter");
+      return NextResponse.json(
+        { status: 400, error: "Invalid location parameter" },
+        { status: 400 }
+      );
+    }
+
+    const locations = await getLocations();
+    const location = locations.locations.find((l) => l.id === locationId);
+    if (!location) {
+      const durationMs = end();
+      log.warn({ status: 404, durationMs, locationId }, "Location not found");
+      return NextResponse.json(
+        { status: 404, error: `Location not found: ${locationId}` },
+        { status: 404 }
+      );
+    }
+
+    const { courses, count } = await getCourses(locationId, {
+      includeDetails: true,
+    });
+
+    const ics = generateCourseIcs(locationId, courses, {
+      calendarName: `VHS Vorpommern-Greifswald – ${location.name} – Kurse`,
+      calendarDescription: `Kurse der Volkshochschule Vorpommern-Greifswald – Standort ${location.name}`,
+      timezone: "Europe/Berlin",
+    });
+
+    const headers = new Headers();
+    headers.set("Content-Type", "text/calendar; charset=utf-8");
+    headers.set(
+      "Content-Disposition",
+      `attachment; filename="${locationId}-courses.ics"`
+    );
+    headers.set("Cache-Control", `public, max-age=${FIFTEEN_MIN_SECONDS}`);
+
+    const durationMs = end();
+    log.info(
+      { status: 200, durationMs, locationId, count },
+      "ICS response generated"
+    );
+
+    return new NextResponse(ics, {
+      status: 200,
+      headers,
+    });
+  } catch (err) {
+    const durationMs = end();
+    log.error(
+      { status: 500, durationMs, err: errorToObject(err) },
+      "ICS handler error"
+    );
+    const message =
+      err instanceof Error ? err.message : "Unknown error generating ICS";
+    return NextResponse.json({ status: 500, error: message }, { status: 500 });
+  }
+}

--- a/src/clients/vhs-website/generate-course-ics.ts
+++ b/src/clients/vhs-website/generate-course-ics.ts
@@ -1,0 +1,115 @@
+import ical, { ICalCalendar } from 'ical-generator';
+import type { Course } from './courses.schema';
+
+/**
+ * Extract categories from our HTML summary.
+ * We look for spans like: <span class="tag">#Bildung</span>
+ * and return ["Bildung", ...].
+ */
+function extractCategoriesFromSummary(summaryHtml?: string): string[] {
+  if (!summaryHtml) return [];
+  try {
+    const matches = Array.from(summaryHtml.matchAll(/<span[^>]*class=["']?tag["']?[^>]*>\s*#([^<]+)\s*<\/span>/gi));
+    const cats = matches.map(m => m[1]?.trim()).filter(Boolean) as string[];
+    // de-duplicate while preserving order
+    const seen = new Set<string>();
+    const out: string[] = [];
+    for (const c of cats) {
+      if (!seen.has(c)) {
+        seen.add(c);
+        out.push(c);
+      }
+    }
+    return out;
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Convert the HTML summary into a plain text string.
+ * - Replace <br> with newlines
+ * - Strip remaining tags
+ * - Collapse whitespace
+ */
+function htmlToPlain(summaryHtml?: string): string {
+  if (!summaryHtml) return '';
+  let s = summaryHtml.replace(/<\s*br\s*\/?>/gi, '\n');
+  s = s.replace(/<[^>]+>/g, ''); // strip tags
+  s = s.replace(/\u00a0/g, ' '); // nbsp to space
+  s = s.split('\n').map(l => l.replace(/\s+/g, ' ').trim()).filter(Boolean).join('\n');
+  return s;
+}
+
+export interface GenerateCourseIcsOptions {
+  timezone?: string; // default: Europe/Berlin
+  calendarName?: string;
+  calendarDescription?: string;
+}
+
+/**
+ * Build an ICS string for a list of courses for a given location.
+ * - SUMMARY: course.title
+ * - DESCRIPTION: uses course.summary (html) and a plain text variant
+ * - DTSTART: course.start (ISO8601); interpreted in Europe/Berlin by consumers
+ * - LOCATION: course.location (optimized address)
+ * - UID: prefixed with VHSVG-
+ * - CATEGORIES: from summary taxonomy tags (#Bildung, #Volkshochschule)
+ * - URL: course.link
+ * - STATUS: CANCELLED if available === false
+ */
+export function generateCourseIcs(
+  locationId: string,
+  courses: Course[],
+  opts: GenerateCourseIcsOptions = {}
+): string {
+  const timezone = opts.timezone ?? 'Europe/Berlin';
+
+  const cal: ICalCalendar = ical({
+    name: opts.calendarName ?? `VHS Vorpommern-Greifswald – ${locationId} – Kurse`,
+    description: opts.calendarDescription ?? 'Kurse der Volkshochschule Vorpommern-Greifswald',
+    timezone,
+    prodId: {
+      company: 'VHSVG',
+      product: 'Course API',
+      language: 'DE',
+    },
+    ttl: 60 * 15, // 15 minutes
+  });
+
+  const now = new Date();
+
+  for (const c of courses) {
+    const start = c.start ? new Date(c.start) : undefined;
+    if (!start || isNaN(start.getTime())) {
+      // Skip malformed dates
+      continue;
+    }
+
+    // Build description with both plain and HTML when available
+    const html = c.summary || '';
+    const plain = htmlToPlain(html);
+    const categories = extractCategoriesFromSummary(html);
+    const status = c.available === false ? 'CANCELLED' : 'CONFIRMED';
+
+    cal.createEvent({
+      id: `VHSVG-${c.id}`,
+      start,
+      // We intentionally omit end if not known; many clients will render a timed start.
+      // If needed later, we can derive end from details.schedule entries.
+      summary: c.title,
+      description: html ? { html, plain } : plain,
+      location: c.location || undefined,
+      url: c.link || undefined,
+      created: now,
+      lastModified: now,
+      status,
+      categories: categories.length ? categories : ['Bildung', 'Volkshochschule'],
+      // Ensure dates are treated as local times in Europe/Berlin context
+      // ical-generator will include TZID from calendar timezone.
+      floating: false,
+    });
+  }
+
+  return cal.toString();
+}

--- a/src/clients/vhs-website/generate-course-ics.ts
+++ b/src/clients/vhs-website/generate-course-ics.ts
@@ -1,4 +1,4 @@
-import ical, { ICalCalendar } from 'ical-generator';
+import ical, { ICalCalendar, ICalEventStatus, ICalCategoryData } from 'ical-generator';
 import type { Course } from './courses.schema';
 
 /**
@@ -90,7 +90,12 @@ export function generateCourseIcs(
     const html = c.summary || '';
     const plain = htmlToPlain(html);
     const categories = extractCategoriesFromSummary(html);
-    const status = c.available === false ? 'CANCELLED' : 'CONFIRMED';
+    const status: ICalEventStatus = c.available === false ? ICalEventStatus.CANCELLED : ICalEventStatus.CONFIRMED;
+    
+    // Convert string categories to ICalCategoryData format
+    const categoryData: ICalCategoryData[] = categories.length 
+      ? categories.map(cat => ({ name: cat }))
+      : [{ name: 'Bildung' }, { name: 'Volkshochschule' }];
 
     cal.createEvent({
       id: `VHSVG-${c.id}`,
@@ -104,7 +109,7 @@ export function generateCourseIcs(
       created: now,
       lastModified: now,
       status,
-      categories: categories.length ? categories : ['Bildung', 'Volkshochschule'],
+      categories: categoryData,
       // Ensure dates are treated as local times in Europe/Berlin context
       // ical-generator will include TZID from calendar timezone.
       floating: false,


### PR DESCRIPTION
This PR implements an ICS/iCal calendar export endpoint for the Course API at `/api/{location}/courses/ics`, parallel to the existing JSON endpoint. The new functionality leverages the `ical-generator` package to produce an iCalendar file based on course data retrieved from the existing API. Key features include:

- ICS generation from course details with proper field mapping (SUMMARY, DESCRIPTION, DTSTART, LOCATION, UID, CATEGORIES).
- Error handling for invalid parameters and course availability.
- Returns the ICS file with appropriate headers for downloading.
- Categories are extracted from the course summary, and dates are managed according to the Europe/Berlin timezone.

This addition addresses issue #21, enhancing usability by allowing users to export course schedules in a widely supported calendar format.

---

> This pull request was co-created with Cosine Genie

Original Task: [vhs-vg-courses/onetv2ohhq1n](https://cosine.sh/bitgrip/vhs-vg-courses/task/onetv2ohhq1n)
Author: Jan-Henrik Hempel
